### PR TITLE
qutebrowserw: Fix argument handling

### DIFF
--- a/default/bin/qutebrowserw
+++ b/default/bin/qutebrowserw
@@ -34,5 +34,5 @@ fi
 
 qutebrowser -B "$base_dir" \
 -s window.title_format "{perc}[$profile] - {current_title}{title_sep}qutebrowser" \
-$@
+"$@"
 


### PR DESCRIPTION
You linked your script in IRC but left already, so I'm opening a PR instead :laughing: 

`$@` incorrectly handles arguments with spaces in them - you probably want `"$@"` instead, so e.g. `qutebrowserw ":jseval alert('test')"` is handled as one argument (and works correctly) instead of being split into two.

See e.g. https://github.com/koalaman/shellcheck/wiki/SC2068